### PR TITLE
Support parameters via querystring

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,20 +60,6 @@
         map.setMapTypeId(google.maps.MapTypeId.ROADMAP);
         map.setOptions({styles:map_style.google_maps_customization_style});
 
-        var TorqueOptions = {
-            user:'viz2',
-            table:'ow',
-            column:'date',
-            steps:750,
-            resolution:2,
-            cumulative:false,
-            clock:true,
-            fps:20,
-            fitbounds:false,
-            blendmode:'lighter',
-            trails:true,
-            point_type:'circle',
-            cellsize:1
         function getParameterByName(name) {
             name = name.replace(/[\[]/, "\\\[").replace(/[\]]/, "\\\]");
             var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
@@ -85,6 +71,39 @@
         var user = getParameterByName('user');
         var table = getParameterByName('table');
         var column = getParameterByName('column');
+
+        if (user != '' && table != '' && column != '') {
+            var TorqueOptions = {
+                user:user,
+                table:table,
+                column:column,
+                steps:750,
+                resolution:2,
+                cumulative:false,
+                clock:true,
+                fps:20,
+                fitbounds:false,
+                blendmode:'lighter',
+                trails:true,
+                point_type:'circle',
+                cellsize:1
+            }
+        } else {
+            var TorqueOptions = {
+                user:'viz2',
+                table:'ow',
+                column:'date',
+                steps:750,
+                resolution:2,
+                cumulative:false,
+                clock:true,
+                fps:20,
+                fitbounds:false,
+                blendmode:'lighter',
+                trails:true,
+                point_type:'circle',
+                cellsize:1
+            }
         }
 
         var torque = null;

--- a/index.html
+++ b/index.html
@@ -76,11 +76,12 @@
             // Get optional parameters from querystring
             var steps = parseInt(getParameterByName('steps'));
             if ( isNaN(steps) ) { steps = 750; }
+            var resolution = parseInt(getParameterByName('resolution'));
+            if ( isNaN(resolution) ) { resolution = 2; }
             var TorqueOptions = {
                 user:user,
                 table:table,
                 column:column,
-                resolution:2,
                 cumulative:false,
                 clock:true,
                 fps:20,
@@ -90,6 +91,7 @@
                 point_type:'circle',
                 cellsize:1
                 steps:steps,
+                resolution:resolution,
             }
         } else {
             var TorqueOptions = {

--- a/index.html
+++ b/index.html
@@ -74,6 +74,12 @@
             trails:true,
             point_type:'circle',
             cellsize:1
+        function getParameterByName(name) {
+            name = name.replace(/[\[]/, "\\\[").replace(/[\]]/, "\\\]");
+            var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
+            results = regex.exec(location.search);
+            return results == null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
+        }
         }
 
         var torque = null;

--- a/index.html
+++ b/index.html
@@ -74,8 +74,8 @@
 
         if (user != '' && table != '' && column != '') {
             // Get optional parameters from querystring
-            var steps = getParameterByName('steps');
-            if ( steps == '' || isNaN(parseInt(steps)) ) { steps = 750; }
+            var steps = parseInt(getParameterByName('steps'));
+            if ( isNaN(steps) ) { steps = 750; }
             var TorqueOptions = {
                 user:user,
                 table:table,

--- a/index.html
+++ b/index.html
@@ -75,27 +75,40 @@
         if (user != '' && table != '' && column != '') {
             // Get optional parameters from querystring
             var steps = parseInt(getParameterByName('steps'));
-            if ( isNaN(steps) ) { steps = 750; }
+            if ( isNaN(steps) ) { steps = 750; } // Does not check for values outside range
             var resolution = parseInt(getParameterByName('resolution'));
-            if ( isNaN(resolution) ) { resolution = 2; }
+            if ( isNaN(resolution) ) { resolution = 2; } // Does not check for steps
             var cumulative = getParameterByName('cumulative');
             if ( cumulative == 'true') { cumulative = true; } else { cumulative = false; }
             var clock = getParameterByName('clock');
             if ( clock == 'false' ) { clock = false; } else { clock = true; }
+            var fps = parseInt(getParameterByName('fps'));
+            if ( isNaN(fps) ) { fps = 20; } // Does not check for values outside range
+            var fitbounds = getParameterByName('fitbounds');
+            if ( fitbounds == 'false') { fitbounds = false; } else { fitbounds = true; }
+            var blendmode = getParameterByName('blendmode');
+            if ( blendmode == '') { blendmode = 'lighter'; } // Does not check for values outside range
+            var trails= getParameterByName('trails');
+            if ( trails == 'false') { trails = false; } else { trails = true; }
+            var point_type = getParameterByName('point_type');
+            if ( point_type == 'square') { point_type = 'square'; } else { point_type = 'circle'; } // Only accepts two values
+            var cellsize = parseInt(getParameterByName('cellsize'));
+            if ( isNaN(cellsize) ) { cellsize = 1; } // Does not check for values outside range
+
             var TorqueOptions = {
                 user:user,
                 table:table,
                 column:column,
-                fps:20,
-                fitbounds:false,
-                blendmode:'lighter',
-                trails:true,
-                point_type:'circle',
-                cellsize:1
                 steps:steps,
                 resolution:resolution,
                 cumulative:cumulative,
                 clock:clock,
+                fps:fps,
+                fitbounds:fitbounds,
+                blendmode:blendmode,
+                trails:trails,
+                point_type:point_type,
+                cellsize:cellsize
             }
         } else {
             var TorqueOptions = {

--- a/index.html
+++ b/index.html
@@ -73,11 +73,13 @@
         var column = getParameterByName('column');
 
         if (user != '' && table != '' && column != '') {
+            // Get optional parameters from querystring
+            var steps = getParameterByName('steps');
+            if ( steps == '' || isNaN(parseInt(steps)) ) { steps = 750; }
             var TorqueOptions = {
                 user:user,
                 table:table,
                 column:column,
-                steps:750,
                 resolution:2,
                 cumulative:false,
                 clock:true,
@@ -87,6 +89,7 @@
                 trails:true,
                 point_type:'circle',
                 cellsize:1
+                steps:steps,
             }
         } else {
             var TorqueOptions = {

--- a/index.html
+++ b/index.html
@@ -67,65 +67,56 @@
             return results == null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
         }
 
-        // Get required parameters from querystring
+        // Get parameters from querystring
         var user = getParameterByName('user');
         var table = getParameterByName('table');
         var column = getParameterByName('column');
+        var steps = parseInt(getParameterByName('steps'));
+        var resolution = parseInt(getParameterByName('resolution'));
+        var cumulative = getParameterByName('cumulative');   
+        var clock = getParameterByName('clock');
+        var fps = parseInt(getParameterByName('fps'));
+        var fitbounds = getParameterByName('fitbounds');
+        var blendmode = getParameterByName('blendmode');
+        var trails = getParameterByName('trails');
+        var point_type = getParameterByName('point_type');
+        var cellsize = parseInt(getParameterByName('cellsize'));
 
-        if (user != '' && table != '' && column != '') {
-            // Get optional parameters from querystring
-            var steps = parseInt(getParameterByName('steps'));
-            if ( isNaN(steps) ) { steps = 750; } // Does not check for values outside range
-            var resolution = parseInt(getParameterByName('resolution'));
-            if ( isNaN(resolution) ) { resolution = 2; } // Does not check for steps
-            var cumulative = getParameterByName('cumulative');
-            if ( cumulative == 'true') { cumulative = true; } else { cumulative = false; }
-            var clock = getParameterByName('clock');
-            if ( clock == 'false' ) { clock = false; } else { clock = true; }
-            var fps = parseInt(getParameterByName('fps'));
-            if ( isNaN(fps) ) { fps = 20; } // Does not check for values outside range
-            var fitbounds = getParameterByName('fitbounds');
-            if ( fitbounds == 'false') { fitbounds = false; } else { fitbounds = true; }
-            var blendmode = getParameterByName('blendmode');
-            if ( blendmode == '') { blendmode = 'lighter'; } // Does not check for values outside range
-            var trails= getParameterByName('trails');
-            if ( trails == 'false') { trails = false; } else { trails = true; }
-            var point_type = getParameterByName('point_type');
-            if ( point_type == 'square') { point_type = 'square'; } else { point_type = 'circle'; } // Only accepts two values
-            var cellsize = parseInt(getParameterByName('cellsize'));
-            if ( isNaN(cellsize) ) { cellsize = 1; } // Does not check for values outside range
+        // None of the required parameters in querystring -> Use default table.
+        if (user == '' && table == '' && column == '') {
+        // Reason for using && and not ||: if some, but not all required parameters 
+        // are provided, the user probably made a mistake -> No visualization. 
+            user = 'viz2';
+            table = 'ow';
+            column = 'date'
+        }
 
-            var TorqueOptions = {
-                user:user,
-                table:table,
-                column:column,
-                steps:steps,
-                resolution:resolution,
-                cumulative:cumulative,
-                clock:clock,
-                fps:fps,
-                fitbounds:fitbounds,
-                blendmode:blendmode,
-                trails:trails,
-                point_type:point_type,
-                cellsize:cellsize
-            }
-        } else {
-            var TorqueOptions = {
-                user:'viz2',
-                table:'ow',
-                column:'date',
-                steps:750,
-                resolution:2,
-                cumulative:false,
-                clock:true,
-                fps:20,
-                fitbounds:false,
-                blendmode:'lighter',
-                trails:true,
-                point_type:'circle',
-                cellsize:1
-            }
+        // Setting defaults and some error handling
+        if ( isNaN(steps) ) { steps = 750; } // Does not check for values outside range
+        if ( isNaN(resolution) ) { resolution = 2; } // Does not check for steps
+        if ( cumulative == 'true') { cumulative = true; } else { cumulative = false; }
+        if ( clock == 'false' ) { clock = false; } else { clock = true; }
+        if ( isNaN(fps) ) { fps = 20; } // Does not check for values outside range
+        if ( fitbounds == 'false') { fitbounds = false; } else { fitbounds = true; }
+        if ( blendmode == '' ) { blendmode = 'lighter'; } // Does not check for values outside range
+        if ( trails == 'false') { trails = false; } else { trails = true; }
+        if ( point_type == 'square') { point_type = 'square'; } else { point_type = 'circle'; } // Only accepts two values
+        if ( isNaN(cellsize) ) { cellsize = 1; } // Does not check for values outside range
+
+        var TorqueOptions = {
+            user:user,
+            table:table,
+            column:column,
+            steps:steps,
+            resolution:resolution,
+            cumulative:cumulative,
+            clock:clock,
+            fps:fps,
+            fitbounds:fitbounds,
+            blendmode:blendmode,
+            trails:trails,
+            point_type:point_type,
+            cellsize:cellsize
         }
 
         var torque = null;

--- a/index.html
+++ b/index.html
@@ -78,11 +78,12 @@
             if ( isNaN(steps) ) { steps = 750; }
             var resolution = parseInt(getParameterByName('resolution'));
             if ( isNaN(resolution) ) { resolution = 2; }
+            var cumulative = getParameterByName('cumulative');
+            if ( cumulative == 'true') { cumulative = true; } else { cumulative = false; }
             var TorqueOptions = {
                 user:user,
                 table:table,
                 column:column,
-                cumulative:false,
                 clock:true,
                 fps:20,
                 fitbounds:false,
@@ -92,6 +93,7 @@
                 cellsize:1
                 steps:steps,
                 resolution:resolution,
+                cumulative:cumulative,
             }
         } else {
             var TorqueOptions = {

--- a/index.html
+++ b/index.html
@@ -80,11 +80,12 @@
             if ( isNaN(resolution) ) { resolution = 2; }
             var cumulative = getParameterByName('cumulative');
             if ( cumulative == 'true') { cumulative = true; } else { cumulative = false; }
+            var clock = getParameterByName('clock');
+            if ( clock == 'false' ) { clock = false; } else { clock = true; }
             var TorqueOptions = {
                 user:user,
                 table:table,
                 column:column,
-                clock:true,
                 fps:20,
                 fitbounds:false,
                 blendmode:'lighter',
@@ -94,6 +95,7 @@
                 steps:steps,
                 resolution:resolution,
                 cumulative:cumulative,
+                clock:clock,
             }
         } else {
             var TorqueOptions = {

--- a/index.html
+++ b/index.html
@@ -80,6 +80,11 @@
             results = regex.exec(location.search);
             return results == null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
         }
+
+        // Get required parameters from querystring
+        var user = getParameterByName('user');
+        var table = getParameterByName('table');
+        var column = getParameterByName('column');
         }
 
         var torque = null;


### PR DESCRIPTION
Hi CartoDB folks,

The page at http://cartodb.github.io/torque is really useful to quickly visualize a dataset and we are using this more and more, but we were missing a way to share our visualization with others.

For final visualizations, this can be already done by creating and hosting a html page (e.g. in the examples folder: http://lifewatchinbo.github.io/torque/examples/tracking_eric.html), which also allows you to tune the base map and get rid of the settings panel.

But we wanted a way to share our test visualizations amongst each other, without the need to have access to the server, so I added some code to support parameters via the querystring, which allows you to directly link to a test visualization:

http://lifewatchinbo.github.io/torque/?user=lifewatch-inbo&table=tracking_eric&column=date_time&steps=2000

I'm a Javascript beginner, so I'm probably breaking some coding best practices and the input validation is minimal, but it works and supports all parameters. I noticed there is a `new_torque` branch, so you probably have much cooler features in mind or maybe you have good reasons not to support querystring, but I created a pull request anyway, in case you are interested.

Cheers,

Peter
LifeWatch INBO team