### PR TITLE
allowing update of torque-aggregation-function (aka countby)

### DIFF
--- a/lib/torque/provider.json.js
+++ b/lib/torque/provider.json.js
@@ -383,6 +383,11 @@
         refresh = true;
       }
 
+      if(opt.countby !== undefined && opt.countby !== this.options.countby) {
+        this.options.countby = opt.countby;
+        refresh = true;
+      }
+
       if(opt.data_aggregation !== undefined) {
         var c = opt.data_aggregation === 'cumulative';
         if (this.options.cumulative !== c) {


### PR DESCRIPTION
Through cartodb.com, I've found that whatever aggregation function I tried to use, I always had the same rendering. This came from the torque-aggregation-function (aka countby) not being updated.
