### PR TITLE
Fix typo - remove lines that set strokStyle

### DIFF
--- a/lib/torque/renderer/cartocss_render.js
+++ b/lib/torque/renderer/cartocss_render.js
@@ -5,7 +5,6 @@
   var TAU = Math.PI*2;
   function renderPoint(ctx, st) {
     ctx.fillStyle = st.fillStyle;
-    ctx.strokStyle = st.strokStyle;
     var pixel_size = st['point-radius'];
 
     // render a circle
@@ -41,7 +40,6 @@
 
   function renderRectangle(ctx, st) {
     ctx.fillStyle = st.fillStyle;
-    ctx.strokStyle = st.strokStyle;
     var pixel_size = st['point-radius'];
     var w = pixel_size * 2;
 


### PR DESCRIPTION
Looks like a typo to me, and the strokeStyle is set below conditionally as it should.

In case I'm missing something, apologies for the noise, and feel free to close.
