### PR TITLE
limit the canvas bounds is rendered so firefox does not raise an exception

### DIFF
--- a/lib/torque/leaflet/torque.js
+++ b/lib/torque/leaflet/torque.js
@@ -238,7 +238,14 @@ L.TorqueLayer = L.CanvasLayer.extend({
           var c = tile._tileCache = document.createElement('canvas');
           c.width = c.height = tile_size;
           pos = this.getTilePos(tile.coord);
-          c.getContext('2d').drawImage(this.getCanvas(), pos.x, pos.y, tile_size, tile_size, 0, 0, tile_size, tile_size);
+          // clip bounds, firefox raise an exception when try to get data from outside canvas
+          var x = Math.max(0, pos.x)
+          var y = Math.max(0, pos.y)
+          var w = Math.min(tile_size, this.getCanvas().width - x);
+          var h = Math.min(tile_size, this.getCanvas().height - y);
+          if (w > 0 && h > 0) {
+            c.getContext('2d').drawImage(this.getCanvas(), x, y, w, h, x - pos.x, y - pos.y, w, h);
+          }
         }
       }
     }


### PR DESCRIPTION
cc @rochoa 
