### PR TITLE
Adjusts tile xy value when coordinates are out of bounds

### DIFF
--- a/lib/torque/leaflet/leaflet_tileloader_mixin.js
+++ b/lib/torque/leaflet/leaflet_tileloader_mixin.js
@@ -116,6 +116,7 @@ L.Mixin.TileLoader = {
       for (j = bounds.min.y; j <= bounds.max.y; j++) {
           for (i = bounds.min.x; i <= bounds.max.x; i++) {
               point = new L.Point(i, j);
+              this._adjustTilePoint(point);
               point.zoom =  zoom;
 
               if (this._tileShouldBeLoaded(point)) {
@@ -143,5 +144,36 @@ L.Mixin.TileLoader = {
       }
       this.fire("tilesLoading");
 
+  },
+  _adjustTilePoint: function (tilePoint) {
+
+    var limit = this._getWrapTileNum();
+
+    // wrap tile coordinates
+    if (!this.options.continuousWorld && !this.options.noWrap) {
+      tilePoint.x = ((tilePoint.x % limit.x) + limit.x) % limit.x;
+    }
+
+    if (this.options.tms) {
+      tilePoint.y = limit.y - tilePoint.y - 1;
+    }
+  },
+  _getWrapTileNum: function () {
+    var crs = this._map.options.crs,
+        size = crs.getSize(this._map.getZoom());
+    return size.divideBy(this._getTileSize())._floor();
+  },
+  _getTileSize: function () {
+    var map = this._map,
+        zoom = map.getZoom() + this.options.zoomOffset,
+        zoomN = this.options.maxNativeZoom,
+        tileSize = this.options.tileSize;
+
+    if (zoomN && zoom > zoomN) {
+      tileSize = Math.round(map.getZoomScale(zoom) / map.getZoomScale(zoomN) * tileSize);
+    }
+
+    return tileSize;
   }
+
 }


### PR DESCRIPTION
Ref #77 

This adds a private function from Leaflet that adjusts the coordinate values whenever they are out of bounds (i.e. outside of -90:90/-180:180), which we were missing in ```_addTilesFromCenterOut```.

Right now this doesn't mean it will display Torque data when the viewport is out of bounds. @javisantana do we want that to be its behaviour?