### PR TITLE
Add cartocss doc

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -21,15 +21,15 @@ One of two core classes for the Torque library - it is used to create an animate
 
 ##### Provider options
 
-| Option    | type       | Default   | Description                            |
-|-----------|:-----------|:----------|:---------------------------------------|
-| provider  | string     | ```sql_api```   | Where is the data coming from |
+| Option    | type       | Default   | Description                            | Options |
+|-----------|:-----------|:----------|:---------------------------------------|---------|
+| provider  | string     | ```sql_api```   | Where is the data coming from    | `sql_api`, `url_template`, or `windshaft` |
 
 ##### CartoDB data options (SQL API provider)
 
 | Option    | type       | Default   | Description                            |
 |-----------|:-----------|:----------|:---------------------------------------|
-| user      | string     | ```null```      | CartoDB account name. Found as, accountname.cartodb.com|
+| user      | string     | ```null```      | CartoDB account name. Found from: http://accountname.cartodb.com|
 | table     | string     | ```null```      | CartoDB table name where data is found  |
 | sql       | string     | ```null```      | SQL query to be performed to fetch the data. You must use this param or table, not at the same time |
 
@@ -54,7 +54,7 @@ One of two core classes for the Torque library - it is used to create an animate
 |-----------|:-----------|:----------|:---------------------------------------|
 | ```setCartoCSS(cartocss)``` | ```cartocss string```    | ```this```   | style the map rendering using client-side cartocss | 
 
-The full CartoCSS spec is not supported by Torque but instead only a limited subset with some additions related to torque rendering. To see the full list of supported parameters, read the [Torque CartoCSS documentation here](CartoCSS.md). ``value`` and ``zoom`` variables can be used. ``value`` is the value of aggregation (see ``countby`` constructor option). ``zoom`` is the current zoom being rendered
+The full CartoCSS spec is not supported by Torque but instead only a limited subset with some additions related to torque rendering. To see the full list of supported parameters, read the [Torque CartoCSS documentation](CartoCSS.md). ``value`` and ``zoom`` variables can be used. ``value`` is the value of aggregation (see ``countby`` constructor option). ``zoom`` is the current zoom being rendered
 
 TorqueLayer currently expects ```marker``` styling
 
@@ -89,8 +89,8 @@ This should be ```string``` encoded in Javascript
 # Google Maps Layers
 
 ## GMapsTorqueLayer(options) 
-This class does exactly the same than ``L.TorqueLayer`` but using Google Maps. The main difference is that this class
-is not a layer is a overlay so in order to add it to the map use ``layer.setMap`` instead of ``overlayMapTypes``. See [Overlay view](https://developers.google.com/maps/documentation/javascript/reference#OverlayView) reference in Google Maps API doc. 
+This class does exactly the same as ``L.TorqueLayer`` but using Google Maps instead. The main difference is that this class
+is not a layer but is an overlay, so in order to add it to the a map use, ``layer.setMap`` instead of ``overlayMapTypes``. See the [Overlay View](https://developers.google.com/maps/documentation/javascript/reference#OverlayView) reference in Google Maps API doc.
 
 ### Options
 

--- a/doc/CartoCSS.md
+++ b/doc/CartoCSS.md
@@ -1,0 +1,28 @@
+
+# Torque CartoCSS
+
+
+## buffer-size
+Extra tolerance around the Layer extent (in pixels) used to when querying and (potentially) clipping the layer data during rendering.
+
+## -torque-clear-color
+Color used to clear canvas on each frame.
+
+
+## -torque-frame-count
+Number of animation steps/frames used in the animation. If the data contains a fewer number of total frames, the lesser value will be used.
+
+## -torque-resolution
+Spatial resolution in pixels. A resolution of 1 means no spatial aggregation of the data. Any other resolution of N results in spatial aggregation into cells of NxN pixels. The value N must be power of 2.
+
+## -torque-animation-duration
+Animation duration in seconds.
+
+## -torque-aggregation-function
+A function used to calculate a value from the aggregate data for each cell. See [-torque-resolution](#-torque-resolution).
+
+## -torque-time-attribute
+The table column that contains the time information used create the animation.
+
+## -torque-data-aggregation
+A linear animation will discard previous values while a cumulative animation will accumulate them until it restarts.


### PR DESCRIPTION
Heya, 

1. Adding bare bones CartoCSS references. The document didn't exist. I'll be filling it in a lot more in the coming days.
2. Couple of clean-up changes to the API.md doc. I added another column to the provider options that listed the three possible values, but need to differentiate further for tiled layers (no windshaft?).  