### PR TITLE
Removed buffer-size from doc

### DIFF
--- a/doc/CartoCSS.md
+++ b/doc/CartoCSS.md
@@ -1,13 +1,8 @@
 
 # Torque CartoCSS
 
-
-## buffer-size
-Extra tolerance around the Layer extent (in pixels) used to when querying and (potentially) clipping the layer data during rendering.
-
 ## -torque-clear-color
 Color used to clear canvas on each frame.
-
 
 ## -torque-frame-count
 Number of animation steps/frames used in the animation. If the data contains a fewer number of total frames, the lesser value will be used.


### PR DESCRIPTION
@fdansv 
Removes property that was improperly included in CartoCSS.md doc as mentioned by @javisantana in #90 