### PR TITLE
Checks for image-filters when preloading image-file

### DIFF
--- a/lib/torque/renderer/point.js
+++ b/lib/torque/renderer/point.js
@@ -323,7 +323,8 @@ var filters = require('./torque_filters');
           if (typeof self._icons.itemsToLoad === 'undefined'){
             this._icons.itemsToLoad = img_names.length;
           }
-          if (self._shader.getLayers().some(function(layer){return typeof layer.shader["image-filters"] !== "undefined"})){
+          var filtered = self._shader.getLayers().some(function(layer){return typeof layer.shader["image-filters"] !== "undefined"});
+          if (filtered){
             new_img.crossOrigin = 'Anonymous';
           }
           new_img.onload = function(e){
@@ -337,8 +338,12 @@ var filters = require('./torque_filters');
             }
           };
           new_img.onerror = function(){
+            console.log("wililo");
             self._forcePoints = true;
             self.clearSpriteCache();
+            if(filtered){
+              console.info("Only CORS-enabled, or same domain image-files can be used in combination with image-filters");
+            }
             console.error("Couldn't get marker-file " + this.src);
           };
           this.itemsToLoad++;

--- a/lib/torque/renderer/point.js
+++ b/lib/torque/renderer/point.js
@@ -323,7 +323,9 @@ var filters = require('./torque_filters');
           if (typeof self._icons.itemsToLoad === 'undefined'){
             this._icons.itemsToLoad = img_names.length;
           }
-          new_img.crossOrigin = "Anonymous";
+          if (typeof self._shader.getLayers()[1].shader["image-filters"] !== "undefined"){
+            new_img.crossOrigin = 'Anonymous';
+          }
           new_img.onload = function(e){
             self._icons[this.src] = this;
             if (Object.keys(self._icons).length === img_names.length + 1){

--- a/lib/torque/renderer/point.js
+++ b/lib/torque/renderer/point.js
@@ -323,7 +323,7 @@ var filters = require('./torque_filters');
           if (typeof self._icons.itemsToLoad === 'undefined'){
             this._icons.itemsToLoad = img_names.length;
           }
-          if (typeof self._shader.getLayers()[1].shader["image-filters"] !== "undefined"){
+          if (self._shader.getLayers().some(function(layer){return typeof layer.shader["image-filters"] !== "undefined"})){
             new_img.crossOrigin = 'Anonymous';
           }
           new_img.onload = function(e){


### PR DESCRIPTION
Ref. https://github.com/CartoDB/torque/issues/121

For now this fixes png-markered maps not working now. Checks whether a viz is using image-filters and if that's not the case it disables the cors header.

@javisantana 