### PR TITLE
Error handling in torque

### DIFF
--- a/doc/API.md
+++ b/doc/API.md
@@ -90,6 +90,7 @@ This should be ```string``` encoded in Javascript.
 | Method    | options    | returns   | Description                            |
 |-----------|:-----------|:----------|:---------------------------------------|
 | ```setSQL(sql statement)``` | ```SQL string```    | ```this```   | Change the SQL on the data table | 
+| ```error(callback)``` | ```callback function with a list of errors as argument```    | ```this```   | specifies a callback function to run if there are query errors | 
 
 ##### SQL Example
 

--- a/examples/navy_gmaps.html
+++ b/examples/navy_gmaps.html
@@ -9,8 +9,7 @@
 
 
     <script src="http://maps.googleapis.com/maps/api/js?sensor=false"></script>
-    <script src="vendor/carto.js"></script>
-    <script src="../dist/torque.uncompressed.js"></script>
+    <script src="../dist/torque.full.uncompressed.js"></script>
 
 
     <script>

--- a/examples/navy_gmaps.html
+++ b/examples/navy_gmaps.html
@@ -77,7 +77,11 @@
         cartocss: CARTOCSS,
         map: map
       });
-
+      torqueLayer.error(function(err){
+        for(error in err){
+          console.warn(err[error]);
+        }
+      });
       torqueLayer.setMap(map);
       torqueLayer.play()
     }

--- a/examples/navy_leaflet.html
+++ b/examples/navy_leaflet.html
@@ -54,6 +54,11 @@
         table      : 'ow',
         cartocss: CARTOCSS
       });
+      torqueLayer.error(function(err){
+        for(error in err){
+          console.warn(err[error]);
+        }
+      });
       torqueLayer.addTo(map);
       torqueLayer.play()
     </script>

--- a/lib/torque/gmaps/torque.js
+++ b/lib/torque/gmaps/torque.js
@@ -338,6 +338,7 @@ GMapsTorqueLayer.prototype = torque.extend({},
   
   error: function (callback) {
     this.options.errorCallback = callback;
+    return this;
   }
 
 });

--- a/lib/torque/gmaps/torque.js
+++ b/lib/torque/gmaps/torque.js
@@ -91,6 +91,7 @@ GMapsTorqueLayer.prototype = torque.extend({},
 
     this.provider = new this.providers[this.options.provider](this.options);
     this.renderer = new this.renderers[this.options.renderer](this.getCanvas(), this.options);
+    this.renderer.options.errorCallback = this.options.errorCallback;
 
     // this listener should be before tile loader
     this._cacheListener = google.maps.event.addListener(this.options.map, 'zoom_changed', function() {
@@ -333,6 +334,10 @@ GMapsTorqueLayer.prototype = torque.extend({},
       }
     }
     return sum;
+  },
+  
+  error: function (callback) {
+    this.options.errorCallback = callback;
   }
 
 });

--- a/lib/torque/leaflet/canvas_layer.js
+++ b/lib/torque/leaflet/canvas_layer.js
@@ -176,6 +176,7 @@ L.CanvasLayer = L.Class.extend({
 
   error: function (callback) {
     this.provider.options.errorCallback = callback;
+    return this;
   },
 
   setOpacity: function (opacity) {

--- a/lib/torque/leaflet/canvas_layer.js
+++ b/lib/torque/leaflet/canvas_layer.js
@@ -174,6 +174,10 @@ L.CanvasLayer = L.Class.extend({
     return this;
   },
 
+  error: function (callback) {
+    this.provider.options.errorCallback = callback;
+  },
+
   setOpacity: function (opacity) {
     this.options.opacity = opacity;
     this._updateOpacity();

--- a/lib/torque/provider/windshaft.js
+++ b/lib/torque/provider/windshaft.js
@@ -459,6 +459,13 @@
       torque.net.jsonp(url, function (data) {
         map_instance_time.end();
         if (data) {
+          if (data.errors){
+            for (error in data.errors){
+              console.error(data.errors[error]);
+              return;
+            }
+            
+          }
           var torque_key = Object.keys(data.metadata.torque)[0]
           var opt = data.metadata.torque[torque_key];
           for(var k in opt) {

--- a/lib/torque/provider/windshaft.js
+++ b/lib/torque/provider/windshaft.js
@@ -460,7 +460,7 @@
         map_instance_time.end();
         if (data) {
           if (data.errors){
-            self.options.errorCallback(data.errors);
+            self.options.errorCallback && self.options.errorCallback(data.errors);
             return;
           }
           var torque_key = Object.keys(data.metadata.torque)[0]

--- a/lib/torque/provider/windshaft.js
+++ b/lib/torque/provider/windshaft.js
@@ -460,7 +460,7 @@
         map_instance_time.end();
         if (data) {
           if (data.errors){
-            this.options.errorCallback(data.errors);
+            self.options.errorCallback(data.errors);
             return;
           }
           var torque_key = Object.keys(data.metadata.torque)[0]
@@ -479,7 +479,7 @@
         } else {
           Profiler.metric('torque.provider.windshaft.layergroup.error').inc();
         }
-      }.bind(this), { callbackName: self.options.instanciateCallback });
+      }, { callbackName: self.options.instanciateCallback });
     }
 
   };

--- a/lib/torque/provider/windshaft.js
+++ b/lib/torque/provider/windshaft.js
@@ -460,11 +460,8 @@
         map_instance_time.end();
         if (data) {
           if (data.errors){
-            for (error in data.errors){
-              console.error(data.errors[error]);
-              return;
-            }
-            
+            this.options.errorCallback(data.errors);
+            return;
           }
           var torque_key = Object.keys(data.metadata.torque)[0]
           var opt = data.metadata.torque[torque_key];
@@ -482,7 +479,7 @@
         } else {
           Profiler.metric('torque.provider.windshaft.layergroup.error').inc();
         }
-      }, { callbackName: self.options.instanciateCallback });
+      }.bind(this), { callbackName: self.options.instanciateCallback });
     }
 
   };


### PR DESCRIPTION
Ref #169 

This adds a ```.error``` method to the torqueLayer API. It works in both Leaflet and Google Maps. I've added documentation in docs/API.md and error handling to a couple of examples.

@javisantana 