### PR TITLE
Doesn't add sprites to images flags if from Firefox

### DIFF
--- a/lib/torque/core.js
+++ b/lib/torque/core.js
@@ -76,7 +76,7 @@
   }
 
   var flags = {
-    sprites_to_images: userAgent().indexOf('Safari') === -1
+    sprites_to_images: userAgent().indexOf('Safari') === -1 && userAgent().indexOf('Firefox') === -1
   };
 
 module.exports = {


### PR DESCRIPTION
Ref. #177 

Fixes marker-file functionality in Firefox by disabling that flag, which we don't need. Also, this should improve the performance of torque maps in Firefox. The problem is that Firefox doesn't allow the use of the toDataURL() method with canvases using images from other domains.

cc @javisantana @RaulVila