### PR TITLE
Matches inertia effect to Leaflet's

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,19 +9,9 @@ JS_CLIENT_FILES= lib/torque/*.js \
 	lib/torque/leaflet/canvas_layer.js \
 	lib/torque/leaflet/torque.js 
 
-all: dist/torque.js dist/torque.full.js
 
 dist/torque.full.uncompressed.js: dist_folder dist/torque.uncompressed.js
 	$(BROWSERIFY) lib/torque/index.js --standalone torque > dist/torque.full.uncompressed.js
-
-dist/torque.full.js: dist_folder dist/torque.full.uncompressed.js
-	$(UGLIFYJS) dist/torque.full.uncompressed.js > dist/torque.full.js
-
-dist/torque.uncompressed.js: dist_folder $(JS_CLIENT_FILES)
-	$(BROWSERIFY) lib/torque/index.js --no-bundle-external --standalone torque > dist/torque.uncompressed.js
-
-dist/torque.js: dist_folder dist/torque.uncompressed.js
-	$(UGLIFYJS) dist/torque.uncompressed.js > dist/torque.js
 
 dist_folder:
 	mkdir -p dist

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 2.11.3
     - Limited sprite radius to a maximum of 255px
     - Fixed custom marker-file functionality in Firefox
+    - Fixed inertia mismatch of Torque's canvas layer
 2.11.2
     - Added error handling to Torque
     - Fixed 'remove' event triggering when removing a Torque layer.

--- a/lib/torque/leaflet/canvas_layer.js
+++ b/lib/torque/leaflet/canvas_layer.js
@@ -232,11 +232,11 @@ L.CanvasLayer = L.Class.extend({
 
   // use direct: true if you are inside an animation frame call
   redraw: function(direct) {
+    var domPosition = L.DomUtil.getPosition(this._map.getPanes().mapPane);
+    if (domPosition) {
+      L.DomUtil.setPosition(this._canvas, { x: -domPosition.x, y: -domPosition.y });
+    }
     if (direct) {
-      var domPosition = L.DomUtil.getPosition(this._map.getPanes().mapPane);
-      if (domPosition) {
-        L.DomUtil.setPosition(this._canvas, { x: -domPosition.x, y: -domPosition.y });
-      }
       this.render();
     } else {
       this._render();

--- a/lib/torque/leaflet/canvas_layer.js
+++ b/lib/torque/leaflet/canvas_layer.js
@@ -85,7 +85,7 @@ L.CanvasLayer = L.Class.extend({
     }, this);
 
     map.on({ 'viewreset': this._reset }, this);
-    map.on('move', this.render, this);
+    map.on('move', this.redraw, this);
     map.on('resize', this._reset, this);
 
     if (this.options.zoomAnimation) {
@@ -233,6 +233,10 @@ L.CanvasLayer = L.Class.extend({
   // use direct: true if you are inside an animation frame call
   redraw: function(direct) {
     if (direct) {
+      var domPosition = L.DomUtil.getPosition(this._map.getPanes().mapPane);
+      if (domPosition) {
+        L.DomUtil.setPosition(this._canvas, { x: -domPosition.x, y: -domPosition.y });
+      }
       this.render();
     } else {
       this._render();

--- a/lib/torque/leaflet/canvas_layer.js
+++ b/lib/torque/leaflet/canvas_layer.js
@@ -85,7 +85,7 @@ L.CanvasLayer = L.Class.extend({
     }, this);
 
     map.on({ 'viewreset': this._reset }, this);
-    map.on('move', this.render, this);
+    map.on('drag', this.render, this);
     map.on('resize', this._reset, this);
 
     if (this.options.zoomAnimation) {

--- a/lib/torque/leaflet/canvas_layer.js
+++ b/lib/torque/leaflet/canvas_layer.js
@@ -85,7 +85,7 @@ L.CanvasLayer = L.Class.extend({
     }, this);
 
     map.on({ 'viewreset': this._reset }, this);
-    map.on('drag', this.render, this);
+    map.on('move', this.render, this);
     map.on('resize', this._reset, this);
 
     if (this.options.zoomAnimation) {

--- a/lib/torque/leaflet/torque.js
+++ b/lib/torque/leaflet/torque.js
@@ -212,10 +212,6 @@ L.TorqueLayer = L.CanvasLayer.extend({
     var canvas = this.getCanvas();
     this.renderer.clearCanvas();
     var ctx = canvas.getContext('2d');
-    var domPosition = L.DomUtil.getPosition(this._map.getPanes().mapPane);
-    if (domPosition) {
-      L.DomUtil.setPosition(this._canvas, { x: -domPosition.x, y: -domPosition.y });
-    }
 
     for(t in this._tiles) {
       tile = this._tiles[t];

--- a/lib/torque/leaflet/torque.js
+++ b/lib/torque/leaflet/torque.js
@@ -212,6 +212,10 @@ L.TorqueLayer = L.CanvasLayer.extend({
     var canvas = this.getCanvas();
     this.renderer.clearCanvas();
     var ctx = canvas.getContext('2d');
+    var domPosition = L.DomUtil.getPosition(this._map.getPanes().mapPane);
+    if (domPosition) {
+      L.DomUtil.setPosition(this._canvas, { x: -domPosition.x, y: -domPosition.y });
+    }
 
     for(t in this._tiles) {
       tile = this._tiles[t];


### PR DESCRIPTION
Ref. #92 

With each ```render``` call, adjusts the position of the canvas to match the map's.

Before:
![acbefore](https://cloud.githubusercontent.com/assets/3707222/7475594/d7c8c93c-f348-11e4-9354-e09dde489495.gif)

After:
![after](https://cloud.githubusercontent.com/assets/3707222/7475596/dc5f1550-f348-11e4-903c-71b1d31b0dfe.gif)

@javisantana 