### PR TITLE
Fix issue with `_super` being removed from listeners

### DIFF
--- a/lib/torque/gmaps/gmaps_tileloader_mixin.js
+++ b/lib/torque/gmaps/gmaps_tileloader_mixin.js
@@ -21,16 +21,17 @@ GMapsTileLoader.prototype = {
   },
 
   _removeTileLoader: function() {
-    for(var i in this._listeners) {
-      google.maps.event.removeListener(this._listeners[i]);
-    }
+    this._listeners.forEach(function (listener) {
+      google.maps.event.removeListener(listener);
+    });
+    
     this._removeTiles();
   },
 
   _removeTiles: function () {
-      for (var key in this._tiles) {
-        this._removeTile(key);
-      }
+    for (var key in this._tiles) {
+      this._removeTile(key);
+    }
   },
 
   _reloadTiles: function() {


### PR DESCRIPTION
The `_listeners` object is an array, and the for-in returns all items, including functions and private Array items. So instead we treat it like an array.

See https://github.com/CartoDB/cartodb.js/issues/478#issuecomment-102415466 for more details.