### PR TITLE
Invalidates view on show() if steps are one

### DIFF
--- a/lib/torque/gmaps/torque.js
+++ b/lib/torque/gmaps/torque.js
@@ -118,7 +118,9 @@ GMapsTorqueLayer.prototype = torque.extend({},
     if(!this.hidden) return this;
     this.hidden = false;
     this.play();
-    this.options.steps === 1 && this.redraw();
+    if (this.options.steps === 1){
+      this.redraw();
+    }
     return this;
   },
 

--- a/lib/torque/gmaps/torque.js
+++ b/lib/torque/gmaps/torque.js
@@ -118,6 +118,7 @@ GMapsTorqueLayer.prototype = torque.extend({},
     if(!this.hidden) return this;
     this.hidden = false;
     this.play();
+    this.options.steps === 1 && this.redraw();
     return this;
   },
 

--- a/lib/torque/leaflet/torque.js
+++ b/lib/torque/leaflet/torque.js
@@ -164,7 +164,9 @@ L.TorqueLayer = L.CanvasLayer.extend({
     if(!this.hidden) return this;
     this.hidden = false;
     this.play();
-    this.options.steps === 1 && this.redraw();
+    if (this.options.steps === 1){
+      this.redraw();
+    }
     return this;
   },
 

--- a/lib/torque/leaflet/torque.js
+++ b/lib/torque/leaflet/torque.js
@@ -164,6 +164,7 @@ L.TorqueLayer = L.CanvasLayer.extend({
     if(!this.hidden) return this;
     this.hidden = false;
     this.play();
+    this.options.steps === 1 && this.redraw();
     return this;
   },
 


### PR DESCRIPTION
Fixes #194 
This makes sure that points are rendered when using show() on a hidden, static torque layer.

@javisantana @iriberri 