### PR TITLE
Add default on* handlers for gmaps torque

### DIFF
--- a/lib/torque/gmaps/torque.js
+++ b/lib/torque/gmaps/torque.js
@@ -32,7 +32,17 @@ function GMapsTorqueLayer(options) {
     if(self.key !== k) {
       self.setKey(k);
     }
-  }, torque.clone(this.options));
+  }, torque.extend(torque.clone(this.options), {
+    onPause: function() {
+      self.fire('pause');
+    },
+    onStop: function() {
+      self.fire('stop');
+    },
+    onStart: function() {
+      self.fire('play');
+    }
+  }));
 
   this.play = this.animator.start.bind(this.animator);
   this.stop = this.animator.stop.bind(this.animator);


### PR DESCRIPTION
Should fix https://github.com/CartoDB/torque/issues/213

Basically the `onPlay`, `onPause` and `onStop` are never triggered, since they don't exist, and the associated events aren't fired and the `toggleButton` method is never triggered [here](https://github.com/CartoDB/cartodb.js/blob/378291ffa9115d20610ba0d78f08525f2f60c68e/src/geo/ui/time_slider.js#L56).