### PR TITLE
Pass extra_params to server

### DIFF
--- a/lib/torque/provider/tilejson.js
+++ b/lib/torque/provider/tilejson.js
@@ -249,11 +249,13 @@
       var limit_x = Math.pow(2, zoom);
       var corrected_x = ((coord.x % limit_x) + limit_x) % limit_x;
       var index = Math.abs(corrected_x + coord.y) % subdomains.length;
+      var extra = this._extraParams();
       var url = this.templateUrl
                 .replace('{x}', corrected_x)
                 .replace('{y}', coord.y)
                 .replace('{z}', zoom)
                 .replace('{s}', subdomains[index])
+      url += extra;
       torque.net.get( url , function (data) {
         if (data && data.responseText) {
           var rows = JSON.parse(data.responseText);


### PR DESCRIPTION
I noticed the extra_params were ignored, which makes it hard to push run-time information back to the server. This naive approach worked for me.