### PR TITLE
Bi provider bounding box histogram

### DIFF
--- a/lib/torque/leaflet/torque.js
+++ b/lib/torque/leaflet/torque.js
@@ -211,6 +211,28 @@ L.TorqueLayer = L.CanvasLayer.extend({
       callback(this.valuesForCatVariable(variable))
     }
   },
+
+  getHistogramForVisibleRegion:function(varName,callback){
+    var center = this._map.getCenter()
+    var zoom   = this._map.getZoom()
+
+    var xtile = parseInt(Math.floor( (center.lng + 180) / 360 * (1<<zoom) ));
+    var ytile = parseInt(Math.floor( (1 - Math.log(Math.tan(center.lat*Math.PI/180.0) + 1 / Math.cos(center.lat*Math.PI/180.0)) / Math.PI) / 2 * (1<<zoom) ));
+    var xx = xtile >> 2
+    var yy = ytile >> 2
+    var z  = zoom - 2
+
+    this.provider.getHistogramForTiles(varName,[{x:xx,y:yy,z:z}],callback)
+  },
+
+  getHistogramForVisibleRegionBetter:function(varName,callback){
+    var tiles= []
+    for(var key in this._tiles){
+      tiles.push(this._tiles[key].coord)
+    }
+    this.provider.getHistogramForTiles(varName,tiles,callback)
+  },
+
   getHistogram:function(variable,callback,noBins){
     var type= this.provider._mapping[variable].type
     if(type=='float'){
@@ -221,6 +243,7 @@ L.TorqueLayer = L.CanvasLayer.extend({
     }
     return this
   },
+
   histogramForCatVariable:function(variable){
     var result = {}
     this.valuesForCatVariable(variable).forEach(function(point){
@@ -642,8 +665,8 @@ L.TorqueLayer = L.CanvasLayer.extend({
    * returned format is [{ x: .., y: .., value: ...}, .. ]
    */
   getClosestValuesFor: function(x, y, dist, step) {
-    var xf = x + dist, 
-        yf = y + dist, 
+    var xf = x + dist,
+        yf = y + dist,
         _x = x;
     var values = []
     for(_y = y; _y < yf; _y += this.options.resolution){

--- a/lib/torque/provider/filterableJson.js
+++ b/lib/torque/provider/filterableJson.js
@@ -590,6 +590,57 @@ var Profiler = require('../profiler');
       this._setReady(true);
     },
 
+    _generateBoundsQuery:function(tiles){
+      return tiles.map( function(tile){
+        return "(quadkey between (xyz2range("+tile.x+","+tile.y+","+tile.z+")).min and (xyz2range("+tile.x+","+tile.y+","+tile.z+")).max)"
+      }).join(" or ")
+    },
+
+    getHistogramForTiles: function(varName,tiles,callback){
+
+      var sql = [
+      'with width as (',
+         'select min({varName}) as min,',
+                 'max({varName}) as max,',
+                '{bins} as buckets',
+                'from {table}',
+      '),',
+      '_bw as ( select (max - min)/buckets as bw from width ),',
+      'histogram as (',
+        'select width_bucket({varName}, min, max, buckets) as bucket,',
+               'numrange(min({varName})::numeric, max({varName})::numeric, \'[]\') as range,',
+               'count(*) as freq',
+          'from {table}, width ',
+          'where {bounds}',
+          '{filters}',
+          //'where trip_time_in_secs between min and max',
+        'group by bucket',
+        'order by bucket',
+      ')',
+      'select bucket*bw as start, (bucket+1)*bw as end, bucket as bin, lower(range) as min, upper(range) as max, freq from histogram, _bw;'
+      ]
+
+      var filters = this._generateFiltersSQL() ?  " and "+ this._generateFiltersSQL() : ""
+
+      var query = format(sql.join('\n'), this.options, {
+        varName: varName,
+        table: this.options.table,
+        filters: filters,
+        bounds: this._generateBoundsQuery(tiles),
+        bins: 20
+      });
+
+      var self = this;
+      this.sql(query, function (data) {
+        if (data) {
+          var rows = JSON.parse(data.responseText).rows;
+          callback(rows);
+        } else {
+          callback(null);
+        }
+      });
+    },
+
     getHistogram: function(varName, callback) {
 
       var sql = [
@@ -605,6 +656,7 @@ var Profiler = require('../profiler');
                'numrange(min({column})::numeric, max({column})::numeric, \'[]\') as range,',
                'count(*) as freq',
           'from {table}, width ',
+          'where {filters}',
           //'where trip_time_in_secs between min and max',
         'group by bucket',
         'order by bucket',
@@ -614,8 +666,8 @@ var Profiler = require('../profiler');
 
 
       var query = format(sql.join('\n'), this.options, {
-        column: this.options.column,
-        table: this.options.table, 
+        column: varName,
+        table: this.options.table,
         filters: this._generateFiltersSQL()
       });
 
@@ -623,7 +675,7 @@ var Profiler = require('../profiler');
       this.sql(query, function (data) {
         if (data) {
           var rows = JSON.parse(data.responseText).rows;
-          callback(null, rows);
+          callback(rows);
         } else {
           callback(null);
         }


### PR DESCRIPTION
@javisantana Adding two methods to calculate the histogram of the visible region. One ```getHistogramForVisibleRegion``` uses @pramsey's  idea of getting the histogram for the center tiles grandfather tile. The other ```getHistogramForVisibleRegionBetter``` generates range queries for each visible tile in the SQL.

Including both cause I don't know what performance will be like on the larger dataset. 