### PR TITLE
updated getting started with a more clearly defined workflow and steps

### DIFF
--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -70,13 +70,7 @@ For Torque to work with your table, specify your username, tablename and a Carto
 
 3) Required Torque Libraries  
 
-Torque libraries are automatically generated when the HTML document is added in step one. The following links are resources to the actual code libraries, if you need to reference them for more advanced Torque functionality.
-
-- Export Torque tiles from your CartoDB account, or use a local Postgres installation [https://github.com/CartoDB/torque-gen](https://github.com/CartoDB/torque-gen)
-
-- View the resource for Torque distribution files [https://github.com/CartoDB/torque/blob/master/dist/torque.js](https://github.com/CartoDB/torque/blob/master/dist/torque.js)
-
-- View the [latest release](https://github.com/CartoDB/torque/releases) of the Torque.js source code
+Torque libraries are automatically generated when the HTML document is added in step one. 
 
 4) Optionally, implement Torque Tiles Specifications
 

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -15,9 +15,9 @@ Currently, you can only animate Torque point data. Line, polygon, and multipoint
 **Note:** When importing Torque data, CartoDB uploads and assumes timezones are in UTC format by default. To specify a different timezone format, you must use the SQL API to import data into CartoDB.
 
 
-1.  Prepare a Leaflet map in an HTML page
+1)  Prepare a Leaflet map in an HTML page
 
-```html
+{% highlight html %}
   <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.css" />
   <body>
     <div id="map"></div>
@@ -34,13 +34,13 @@ Currently, you can only animate Torque point data. Line, polygon, and multipoint
       }).addTo(map);
     </script>
   </body>
-```
+{% endhighlight %}
 
-2. Initialize the Torque.js layer
+2) Initialize the Torque.js layer
 
 For Torque to work with your table, specify your username, tablename and a CartoCSS string to style the map. Leaflet's method `addTo` adds the Torque layer to the map. `play` runs the animation with the options specified in the CartoCSS properties
 
-```html
+{% highlight html %}
   <script>
     var CARTOCSS = [
       'Map {',
@@ -66,9 +66,9 @@ For Torque to work with your table, specify your username, tablename and a Carto
     torqueLayer.addTo(map);
     torqueLayer.play()
   </script>
-```
+{% endhighlight %}
 
-3.  Required Torque Libraries  
+3) Required Torque Libraries  
 
 Torque libraries are automatically generated when the HTML document is added in step one. The following links are resources to the actual code libraries, if you need to reference them for more advanced Torque functionality.
 
@@ -78,37 +78,38 @@ Torque libraries are automatically generated when the HTML document is added in 
 
 - View the [latest release](https://github.com/CartoDB/torque/releases) of the Torque.js source code
 
-4. Optionally, implement Torque Tiles Specifications
+4) Optionally, implement Torque Tiles Specifications
 
 Torque tile specifications define the TorqueMap Metadata and tileset information. You can use any kind of tile source outside CartoDB, by specifying the location of a [valid TileJSON](https://github.com/mapbox/tilejson-spec) file:
 
-```javascript
+{% highlight javascript %}
   var torqueLayer = new L.TorqueLayer({
     tileJSON: 'http://url.to/tile.json'
     cartocss: CARTOCSS
   });
-```
+{% endhighlight %}
+
 **Note:** All Torque tile fields in the specification are required.
 
-5. Optionally, it is also possible to run a custom SQL query for your visualization:
+5) Optionally, it is also possible to run a custom SQL query for your visualization:
 
-```javascript
+{% highlight javascript %}
   var torqueLayer = new L.TorqueLayer({
     user       : 'your_username',
     table      : 'your_table_name',
     sql_query  : 'SELECT * FROM your_table_name WHERE whatever'
     cartocss: CARTOCSS
   });
-```
+{% endhighlight %}
 
-Like in a video player, you can use animation control methods such as `play`, `stop` and `pause` at any point. Torque's animator fires a `change:time` event each time the animation "ticks" to the next frame, and there are a number of properties and methods that can be run during playback, which are detailed in the [API documentation](/cartodb-platform/torque/torqueapi/). At any point, for example, the styling of the layer's markers can be changed using the `layer.setCartoCSS('##style##')`.
+Similar to using a video player, you can use animation control methods such as `play`, `stop` and `pause` at any point. Torque's animator fires a `change:time` event each time the animation "ticks" to the next frame, and there are a number of properties and methods that can be run during playback, which are detailed in the [API documentation](/cartodb-platform/torque/torqueapi/). At any point, for example, the styling of the layer's markers can be changed using the `layer.setCartoCSS('##style##')`.
 
-6. Customize your animation 
+6) Customize your animation 
 
-Style and customize your animations with [CartoCSS Properties for Torque Style Maps](/cartodb-platform/cartocss/properties-for-torque/)
+Style and customize your animations with [CartoCSS Properties for Torque Style Maps](/cartodb-platform/cartocss/properties-for-torque/).
 
 ## Usage Examples
-The best way to start learning about the library is by taking a look at some of the examples below:
+The best way to start learning about the library is by viewing some of these examples:
 
 * A basic example using the WWI British Navy dataset - ([view live](http://cartodb.github.io/torque/examples/navy_leaflet.html) / [source code](https://github.com/CartoDB/torque/blob/master/examples/navy_leaflet.html))
 * Using tileJSON to fetch tiles - ([view live](http://cartodb.github.io/torque/examples/tilejson.html) / [source code](https://github.com/CartoDB/torque/blob/master/examples/tilejson.html))

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -15,7 +15,7 @@ Currently, you can only animate Torque point data. Line, polygon, and multipoint
 **Note:** When importing Torque data, CartoDB uploads and assumes timezones are in UTC format by default. To specify a different timezone format, you must use the SQL API to import data into CartoDB.
 
 
-1.  You need to have a Leaflet map prepared in an HTML page
+1.  Prepare a Leaflet map in an HTML page
 
 ```html
   <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.css" />
@@ -68,23 +68,17 @@ For Torque to work with your table, specify your username, tablename and a Carto
   </script>
 ```
 
-3.  Install the required CartoDB Torque Libraries  
+3.  Required Torque Libraries  
 
-The Torque.js library interacts with CartoDB to generate the Torque tile format. If you are hosting your data on an external connector, you can modify the input parameters to redirect to any "Torque tiles service".
-
-Torque Library:
+Torque libraries are generated when the HTML document is added in step one. The following links are resources for alternative code libraries for more advanced Torque functionality.
 
 - Export Torque tiles from your CartoDB account, or use a local Postgres installation [https://github.com/CartoDB/torque-gen](https://github.com/CartoDB/torque-gen)
 
-- Install [https://github.com/CartoDB/torque/blob/master/dist/torque.js](https://github.com/CartoDB/torque/blob/master/dist/torque.js)
+- View the resource for Torque distribution files [https://github.com/CartoDB/torque/blob/master/dist/torque.js](https://github.com/CartoDB/torque/blob/master/dist/torque.js)
 
-Advanced Torque.js Libraries:
+- View the [latest release](https://github.com/CartoDB/torque/releases) of the Torque.js source code
 
-If you are interested in using advanced interaction methods, it is a prerequisite to load the Torque.js library before using the advanced interaction methods.
-
-- Download the [latest release](https://github.com/CartoDB/torque/releases) of the Torque.js source code
-
-4. Include all Torque Tiles Specifications
+4. Optionally, implement Torque Tiles Specifications
 
 Torque tile specifications define the TorqueMap Metadata and tileset information. You can use any kind of tile source outside CartoDB, by specifying the location of a [valid TileJSON](https://github.com/mapbox/tilejson-spec) file:
 
@@ -96,7 +90,7 @@ Torque tile specifications define the TorqueMap Metadata and tileset information
 ```
 **Note:** All Torque tile fields in the specification are required.
 
-5. Optionally, it is also possible to use a custom SQL query for your visualization:
+5. Optionally, it is also possible to run a custom SQL query for your visualization:
 
 ```javascript
   var torqueLayer = new L.TorqueLayer({

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -1,7 +1,6 @@
 # Getting Started
 
-Torque.js is a JavaScript library that enables you to animate time series data. Torque.js uses tile cubes, which are JSON representations of multidimensional data with geospatial coordinates. [Tile cube specifications](http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification
-) render data on the client, to optimize the transfer of temporal and categorical data for maps.
+Torque.js is a JavaScript library that enables you to animate time series data. Torque.js uses tile cubes, which are JSON representations of multidimensional data with geospatial coordinates. [Tile cube specifications](https://github.com/CartoDB/torque-tiles/blob/master/2.0/spec.md) render data on the client, to optimize the transfer of temporal and categorical data for maps.
 
 **Tip:** Torque is both a spatial and temporal aggregator. It does not plot your exact lat/lon points, it lays an invisible grid over your map, and draws one marker for each grid cell that contains points (representing an aggregation of all of the points in the grid cell). You can control the size of this grid with the CartoCSS [`-torque-resolution`](/cartodb-platform/cartocss/properties-for-torque/#torque-resolution-float) property. You are also able to control the type of aggregation with the CartoCSS [`-torque-aggregation-function`](/cartodb-platform/cartocss/properties-for-torque/#torque-aggregation-function-keyword). For more details, see the wiki page about how [Torque aggregates data](https://github.com/CartoDB/torque/wiki/How-spatial-aggregation-works).
 

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -1,6 +1,22 @@
 # Getting Started
 
-Although the most straightforward way to use Torque is through either the CartoDB Editor, or by passing the layer's viz.json to [CartoDB.js](http://docs.cartodb.com/cartodb-platform/cartodb-js/getting-started/), many use cases work best with the standalone [Torque.js](https://github.com/CartoDB/torque/tree/master/dist). Assuming you have a public dataset with a `date` column, it is really simple to create an animated map with the library. First, you need to have a Leaflet map prepared in an HTML page:
+Torque.js is a JavaScript library that enables you to animate time series data. Torque.js uses tile cubes, which are JSON representations of multidimensional data with geospatial coordinates. [Tile cube specifications](http://wiki.osgeo.org/wiki/Tile_Map_Service_Specification
+) render data on the client, to optimize the transfer of temporal and categorical data for maps.
+
+**Tip:** Torque is both a spatial and temporal aggregator. It does not plot your exact lat/lon points, it lays an invisible grid over your map, and draws one marker for each grid cell that contains points (representing an aggregation of all of the points in the grid cell). You can control the size of this grid with the CartoCSS [`-torque-resolution`](/cartodb-platform/cartocss/properties-for-torque/#torque-resolution-float) property. You are also able to control the type of aggregation with the CartoCSS [`-torque-aggregation-function`](/cartodb-platform/cartocss/properties-for-torque/#torque-aggregation-function-keyword). For more details, see the wiki page about how [Torque aggregates data](https://github.com/CartoDB/torque/wiki/How-spatial-aggregation-works).
+
+## Implementing Torque.js
+
+Although the most straightforward way to use Torque is through either the CartoDB Editor, or by passing the layer's viz.json to [CartoDB.js](http://docs.cartodb.com/cartodb-platform/cartodb-js/getting-started/), many use cases work best with the standalone [Torque.js](https://github.com/CartoDB/torque/tree/master/dist). Assuming you have a public dataset with a `date` column, it is really simple to create an animated map with the library. 
+
+**Pre-requisite:** When visualizing Torque style maps, it is required that you normalize your data to show a total count, or a range, of `0`-`255`. For more details, see this description about [statistical normalization](https://books.google.com/books?id=FrUQHIzXK6EC&pg=PT347&lpg=PT347&dq=choropleth+normalization&source=bl&ots=muDZhsb2jT&sig=DbomJnKedQjaKvcQgm_sVqHBt-8&hl=en&sa=X&ved=0CCYQ6AEwAjgKahUKEwje0ee8qaTHAhUCZj4KHRF5CjM#v=onepage&q=choropleth%20normalization&f=false).
+
+Currently, you can only animate Torque point data. Line, polygon, and multipoint data are not supported for Torque animation.
+
+**Note:** When importing Torque data, CartoDB uploads and assumes timezones are in UTC format by default. To specify a different timezone format, you must use the SQL API to import data into CartoDB.
+
+
+1.  You need to have a Leaflet map prepared in an HTML page
 
 ```html
   <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.css" />
@@ -21,7 +37,9 @@ Although the most straightforward way to use Torque is through either the CartoD
   </body>
 ```
 
-For Torque to work with your table, you only need a username, the name of the table, and a CartoCSS string to style the map. Leaflet's method `addTo` adds the Torque layer to the map. `play` runs the animation with the options specified in the CartoCSS properties.
+2. Initialize the Torque.js layer
+
+For Torque to work with your table, specify your username, tablename and a CartoCSS string to style the map. Leaflet's method `addTo` adds the Torque layer to the map. `play` runs the animation with the options specified in the CartoCSS properties
 
 ```html
   <script>
@@ -51,7 +69,25 @@ For Torque to work with your table, you only need a username, the name of the ta
   </script>
 ```
 
-You can use any kind of tile source outside CartoDB, by specifying the location of a [valid TileJSON](https://github.com/mapbox/tilejson-spec) file:
+3.  Install the required CartoDB Torque Libraries  
+
+The Torque.js library interacts with CartoDB to generate the Torque tile format. If you are hosting your data on an external connector, you can modify the input parameters to redirect to any "Torque tiles service".
+
+Torque Library:
+
+- Export Torque tiles from your CartoDB account, or use a local Postgres installation [https://github.com/CartoDB/torque-gen](https://github.com/CartoDB/torque-gen)
+
+- Install [https://github.com/CartoDB/torque/blob/master/dist/torque.js](https://github.com/CartoDB/torque/blob/master/dist/torque.js)
+
+Advanced Torque.js Libraries:
+
+If you are interested in using advanced interaction methods, it is a prerequisite to load the Torque.js library before using the advanced interaction methods.
+
+- Download the [latest release](https://github.com/CartoDB/torque/releases) of the Torque.js source code
+
+4. Include all Torque Tiles Specifications
+
+Torque tile specifications define the TorqueMap Metadata and tileset information. You can use any kind of tile source outside CartoDB, by specifying the location of a [valid TileJSON](https://github.com/mapbox/tilejson-spec) file:
 
 ```javascript
   var torqueLayer = new L.TorqueLayer({
@@ -59,8 +95,9 @@ You can use any kind of tile source outside CartoDB, by specifying the location 
     cartocss: CARTOCSS
   });
 ```
+**Note:** All Torque tile fields in the specification are required.
 
-Optionally, it is also possible to use a custom SQL query for your visualization:
+5. Optionally, it is also possible to use a custom SQL query for your visualization:
 
 ```javascript
   var torqueLayer = new L.TorqueLayer({
@@ -72,6 +109,10 @@ Optionally, it is also possible to use a custom SQL query for your visualization
 ```
 
 Like in a video player, you can use animation control methods such as `play`, `stop` and `pause` at any point. Torque's animator fires a `change:time` event each time the animation "ticks" to the next frame, and there are a number of properties and methods that can be run during playback, which are detailed in the [API documentation](/cartodb-platform/torque/torqueapi/). At any point, for example, the styling of the layer's markers can be changed using the `layer.setCartoCSS('##style##')`.
+
+6. Customize your animation 
+
+Style and customize your animations with [CartoCSS Properties for Torque Style Maps](/cartodb-platform/cartocss/properties-for-torque/)
 
 ## Usage Examples
 The best way to start learning about the library is by taking a look at some of the examples below:

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -111,7 +111,7 @@ Style and customize your animations with [CartoCSS Properties for Torque Style M
 The best way to start learning about the library is by taking a look at some of the examples below:
 
 * A basic example using the WWI British Navy dataset - ([view live](http://cartodb.github.io/torque/examples/navy_leaflet.html) / [source code](https://github.com/CartoDB/torque/blob/master/examples/navy_leaflet.html))
-* Using tileJSON to fetch tiles - ([view live](http://cartodb.github.io/torque/examples/tilejson.html) / [source code](https://github.com/CartoDB/torque/blob/master/examples/tilejson.html))
+* Using tileJSON to fetch tiles - ([view live](https://github.com/CartoDB/torque/blob/master/examples/tilejson.json) / [source code](https://github.com/CartoDB/torque/blob/master/examples/tilejson.html))
 * A car's route at the Nürburgring track mapped in Torque - ([view live](http://cartodb.github.io/torque/examples/car.html) / [source code](https://github.com/CartoDB/torque/blob/master/examples/car.html))
 
 ## Additional Torque Resources

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -70,7 +70,7 @@ For Torque to work with your table, specify your username, tablename and a Carto
 
 3.  Required Torque Libraries  
 
-Torque libraries are generated when the HTML document is added in step one. The following links are resources for alternative code libraries for more advanced Torque functionality.
+Torque libraries are automatically generated when the HTML document is added in step one. The following links are resources to the actual code libraries, if you need to reference them for more advanced Torque functionality.
 
 - Export Torque tiles from your CartoDB account, or use a local Postgres installation [https://github.com/CartoDB/torque-gen](https://github.com/CartoDB/torque-gen)
 

--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -111,7 +111,7 @@ Style and customize your animations with [CartoCSS Properties for Torque Style M
 The best way to start learning about the library is by taking a look at some of the examples below:
 
 * A basic example using the WWI British Navy dataset - ([view live](http://cartodb.github.io/torque/examples/navy_leaflet.html) / [source code](https://github.com/CartoDB/torque/blob/master/examples/navy_leaflet.html))
-* Using tileJSON to fetch tiles - ([view live](https://github.com/CartoDB/torque/blob/master/examples/tilejson.json) / [source code](https://github.com/CartoDB/torque/blob/master/examples/tilejson.html))
+* Using tileJSON to fetch tiles - ([view live](http://cartodb.github.io/torque/examples/tilejson.html) / [source code](https://github.com/CartoDB/torque/blob/master/examples/tilejson.html))
 * A car's route at the Nürburgring track mapped in Torque - ([view live](http://cartodb.github.io/torque/examples/car.html) / [source code](https://github.com/CartoDB/torque/blob/master/examples/car.html))
 
 ## Additional Torque Resources

--- a/doc/torque_api.md
+++ b/doc/torque_api.md
@@ -123,10 +123,6 @@ torqueLayer.setSQL("SELECT * FROM table LIMIT 100");
 
 ### Events
 
-_**Note:** You can only run events after the [required libraries](/cartodb-platform/torque/torquejs-getting-started/#advanced-torquejs-libraries) are loaded. Otherwise, the [interaction methods](/cartodb-platform/torque/torque-interaction-methods/) will not work._
-
-Events in Torque follow the format:
-
 ```js
 torqueLayer.on('event-type', function([callback_obj]) {
   // do something

--- a/doc/torque_interaction_methods.md
+++ b/doc/torque_interaction_methods.md
@@ -1,8 +1,5 @@
 # Advanced Torque.js Interaction Methods
 
-_**Note:** Before applying Torque.js interaction methods, you must first load the [required libraries](http://docs.cartodb.com/cartodb-platform/torque/torquejs-getting-started/#advanced-torquejs-libraries)_.
-
-
 ## Torque Layers
 
 While you can add multiple layers with Torque.js, this is not recommended as it effects performance.


### PR DESCRIPTION
For [Docs issue#644](https://github.com/CartoDB/docs/issues/644)

@fdansv & @rochoa , I know you edited the Torque Getting Started section before it was published, as you didn't think the overview details and workflow needed to be defined for the Developer audience. However, the first comment in regards to the live Torque.js content was that the Getting Started was missing the required library information. I think it's valuable to include these details back into the overview section (as it is not available anywhere else in the docs).  See the propose changes. 