### PR TITLE
Don't throw an exception when a named map tries to set a new cartocss over the torque layer

### DIFF
--- a/lib/torque/gmaps/torque.js
+++ b/lib/torque/gmaps/torque.js
@@ -321,7 +321,13 @@ GMapsTorqueLayer.prototype = torque.extend({},
    * set the cartocss for the current renderer
    */
   setCartoCSS: function(cartocss) {
-    if (this.provider && this.provider.options.named_map) throw new Error("CartoCSS style on named maps is read-only");
+    if (!this.renderer) throw new Error('renderer is not valid');
+
+    if (this.provider && this.provider.options.named_map) {
+      console.log('Torque layer: CartoCSS style on named maps is read-only');
+      return false;
+    }
+    
     var shader = new carto.RendererJS().render(cartocss);
     this.shader = shader;
     if (this.renderer) {

--- a/lib/torque/leaflet/torque.js
+++ b/lib/torque/leaflet/torque.js
@@ -393,7 +393,7 @@ L.TorqueLayer = L.CanvasLayer.extend({
   setCartoCSS: function(cartocss) {
     if (!this.renderer) throw new Error('renderer is not valid');
 
-    if (this.provider.options.named_map) {
+    if (this.provider && this.provider.options.named_map) {
       console.log('Torque layer: CartoCSS style on named maps is read-only');
       return false;
     }

--- a/lib/torque/leaflet/torque.js
+++ b/lib/torque/leaflet/torque.js
@@ -391,8 +391,13 @@ L.TorqueLayer = L.CanvasLayer.extend({
    * set the cartocss for the current renderer
    */
   setCartoCSS: function(cartocss) {
-    if (this.provider.options.named_map) throw new Error("CartoCSS style on named maps is read-only");
     if (!this.renderer) throw new Error('renderer is not valid');
+
+    if (this.provider.options.named_map) {
+      console.log('Torque layer: CartoCSS style on named maps is read-only');
+      return false;
+    }
+
     this.renderer.setCartoCSS(cartocss, function () {
       // provider options
       var options = torque.common.TorqueLayer.optionsFromLayer(this.renderer._shader.findLayer({ name: 'Map' }));


### PR DESCRIPTION
The same as before but not throwing an error, just a console.
Trying to fix https://github.com/CartoDB/cartodb/issues/10964.