### PR TITLE
adds shield-placement-type to torque-reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "license": "BSD-3-Clause",
   "dependencies": {
-    "carto": "cartodb/carto#master",
+    "carto": "cartodb/carto#shield_placement_type",
     "d3": "3.5.17",
     "turbo-carto": "0.19.0",
     "turf-jenks": "~1.0.1"


### PR DESCRIPTION
re: https://github.com/CartoDB/support/issues/894

- carto: https://github.com/CartoDB/carto/pull/47
- torque: https://github.com/CartoDB/torque/pull/293
- carto.js: https://github.com/CartoDB/cartodb.js/pull/2060
- cartodb: https://github.com/CartoDB/cartodb/pull/13612