### PR TITLE
306 fix cannot read undefined layer

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,5 @@
-3.1.0 (2019-mm-dd)
-
+3.1.1 (2019-06-21)
+    - Fixed reading undefined layer #306
 
 3.1.0 (2019-04-02)
     - Upgrade canvas to version 2.4.1

--- a/lib/torque/renderer/point.js
+++ b/lib/torque/renderer/point.js
@@ -57,6 +57,12 @@ var CartoDatasource = require('./datasource');
     return COMP_OP_TO_CANVAS[compop] || compop;
   }
 
+  // Take an input cartocss that may contain comments and remove them
+  var COMMENTS_RE = /\/\*.*?\*\/\n?/mg;
+  function stripComments(cartocss) {
+    return cartocss.replace(COMMENTS_RE, '');
+  }
+
   //
   // this renderer just render points depending of the value
   //
@@ -73,8 +79,7 @@ var CartoDatasource = require('./datasource');
     this._icons = {};
     this._iconsToLoad = 0;
     this._filters = new Filters(this._canvas, {canvasClass: options.canvasClass});
-    this.style = this.options.cartocss || DEFAULT_CARTOCSS;
-    this.setCartoCSS(this.style);
+    this.setCartoCSS(this.options.cartocss || DEFAULT_CARTOCSS);
     this.TILE_SIZE = 256;
     this._style = null;
     this._gradients = {};
@@ -116,11 +121,11 @@ var CartoDatasource = require('./datasource');
     setCartoCSS: function(cartocss, callback) {
       var self = this;
 
-      this.style = cartocss;
+      this.style = stripComments(cartocss);
 
-      if (PointRenderer.isTurboCarto(cartocss)) {
+      if (PointRenderer.isTurboCarto(this.style)) {
         var datasource = new CartoDatasource(self.layer._tiles);
-        turbocarto(cartocss, datasource, function (err, parsedCartoCSS) {
+        turbocarto(this.style, datasource, function (err, parsedCartoCSS) {
           if (err) {
             return callback(err, null);
           }
@@ -131,7 +136,7 @@ var CartoDatasource = require('./datasource');
           callback && callback();
         });
       } else {
-        self.setShader(new carto.RendererJS().render(cartocss));
+        self.setShader(new carto.RendererJS().render(this.style));
         callback && callback();
       }
     },

--- a/lib/torque/renderer/point.js
+++ b/lib/torque/renderer/point.js
@@ -123,7 +123,7 @@ var CartoDatasource = require('./datasource');
 
       this.style = stripComments(cartocss);
 
-      if (PointRenderer.isTurboCarto(this.style)) {
+      if (PointRenderer.isTurboCarto(this.style) && self.layer) {
         var datasource = new CartoDatasource(self.layer._tiles);
         turbocarto(this.style, datasource, function (err, parsedCartoCSS) {
           if (err) {

--- a/test/renderer/point.js
+++ b/test/renderer/point.js
@@ -137,3 +137,38 @@ test('get values for tile', function() {
   equal(v[0], 5);
   equal(v[1], 7);
 });
+
+test('should deal with no layer and commented out cartocss', function() {
+  var css = [
+    'Map {',
+    '  -torque-frame-count: 1;',
+    '  -torque-animation-duration: 30;',
+    '  -torque-time-attribute: "cartodb_id";',
+    '  -torque-aggregation-function: "count(1)";',
+    '  -torque-resolution: 4;',
+    '  -torque-data-aggregation: linear;',
+    '}',
+    '#layer {',
+    '  marker-width: 16.6;',
+    '  /*marker-width: ramp([value], range(2, 40), jenks(6));*/',
+    '  marker-fill-opacity: 1;',
+    '  marker-file: url(http://cartodb-libs.global.ssl.fastly.net/cartodbui/assets/unversioned/images/alphamarker.png);',
+    '  marker-allow-overlap: true;',
+    '  marker-line-width: 1;',
+    '  marker-line-color: #FFFFFF;',
+    '  marker-line-opacity: 1;',
+    '  marker-comp-op: darken;',
+    '  image-filters: colorize-alpha(#4b2991,#872ca2,#c0369d,#ea4f88,#fa7876,#f6a97a,#edd9a3);',
+    '}'
+  ].join('\n');
+
+  var canvas = document.createElement('canvas');
+  var myRenderer = new torque.renderer.Point(canvas, {
+    layer: undefined
+  });
+
+  myRenderer.setCartoCSS(css);
+  var shader = renderer._shader.getLayers()[0];
+  var sprite = myRenderer.generateSprite(shader, 0, { zoom: 0 });
+  notEqual(sprite, null);
+});


### PR DESCRIPTION
This does a couple things:
- it makes sure CartoCSS comments are not taken into account further down the line
- it does not attempt to apply turbocarto if there's no layer definition